### PR TITLE
Chore remove tsconfig.json from published packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,3 @@
 # Changelog
+
+>WIP: Conventional commits is the goal, but that will be later once we take 0.0.1-alpha to 0.0.2.

--- a/_templates/workspace-package/new/.npmignore.ejs.t
+++ b/_templates/workspace-package/new/.npmignore.ejs.t
@@ -4,3 +4,4 @@ to: packages/<%=name%>/.npmignore
 __test__
 *.tsbuildinfo
 jest.config.js
+tsconfig.json

--- a/examples/latest/package.json
+++ b/examples/latest/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@aws-cdk/aws-cognito": "1.126.0",
     "@aws-cdk/core": "1.126.0",
-    "@cdk-utils/vercel-secret-forwarder": "^0.0.1-alpha.67",
+    "@cdk-utils/vercel-secret-forwarder": "0.0.1-alpha.67",
     "@serverless-stack/cli": "0.50.2",
     "@serverless-stack/resources": "0.50.2"
   },

--- a/packages/custom-resources/utils/.npmignore
+++ b/packages/custom-resources/utils/.npmignore
@@ -1,3 +1,4 @@
 __test__
 *.tsbuildinfo
 jest.config.js
+tsconfig.json

--- a/packages/custom-resources/utils/package.json
+++ b/packages/custom-resources/utils/package.json
@@ -11,7 +11,7 @@
     "axios": "0.21.1"
   },
   "devDependencies": {
-    "@cdk-utils/factories": "^0.0.1-alpha.67",
+    "@cdk-utils/factories": "0.0.1-alpha.67",
     "@tsconfig/node14": "1.0.1",
     "@types/jest": "26.0.10",
     "jest": "26.4.2",

--- a/packages/custom-resources/vercel-secret-forwarder/.npmignore
+++ b/packages/custom-resources/vercel-secret-forwarder/.npmignore
@@ -1,6 +1,7 @@
 __test__
 *.tsbuildinfo
 jest.config.js
+tsconfig.json
 
 # CDK asset staging directory
 .cdk.staging

--- a/packages/custom-resources/vercel-secret-forwarder/package.json
+++ b/packages/custom-resources/vercel-secret-forwarder/package.json
@@ -7,7 +7,7 @@
     "name": "Simon Reilly"
   },
   "dependencies": {
-    "@cdk-utils/utils": "^0.0.1-alpha.67",
+    "@cdk-utils/utils": "0.0.1-alpha.67",
     "axios": "0.21.1"
   },
   "devDependencies": {

--- a/packages/factories/.npmignore
+++ b/packages/factories/.npmignore
@@ -1,3 +1,4 @@
 __test__
 jest.config.js
 *.tsbuildinfo
+tsconfig.json


### PR DESCRIPTION
A tsconfig.json in the node modules, will be picked up by VSCode, and that is not a good thing.

We do need to ship some typescript, to be compiled, but that will be compiled at deploy by esbuild in NodeJsFunction.